### PR TITLE
Use the more succinct style of railtie initializer

### DIFF
--- a/lib/is_it_up/railtie.rb
+++ b/lib/is_it_up/railtie.rb
@@ -1,7 +1,7 @@
 module IsItUp
   class Railtie < Rails::Railtie
-    initializer "is_it_up.configure_rails_initialization" do
-      Rails.application.middleware.use IsItUp::Middleware
+    initializer "is_it_up.configure_rails_initialization" do |app|
+      app.middleware.use IsItUp::Middleware
     end
   end
 end


### PR DESCRIPTION
By accepting a block, you can use the `app` block argument to access the middleware collection without needing to reference the `Rails` global.

Ultimately, this is just saving a few characters though.
