### PR TITLE
[DevOps] Rubygems Standards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,69 @@
+---
+# ---------------------------------------------------------------------------------------------------------------------
+# CircleCI Snippets
+#
+# Reusable snippets are defined below this section. These are yaml fragments that can injected into the standard
+# CircleCI configuration, reducing the complexity of the entire block.
+# ---------------------------------------------------------------------------------------------------------------------
+docker_image: &docker_image
+  image: 916869144969.dkr.ecr.us-east-1.amazonaws.com/customink/base-ruby:2.7-v4.0
+  aws_auth:
+    aws_access_key_id: ${PRODUCTION_AWS_ACCESS_KEY_ID}
+    aws_secret_access_key: ${PRODUCTION_AWS_SECRET_ACCESS_KEY}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CircleCI Commands Configuration
+#
+# Commands are re-usable steps that can be shared across jobs. For example the installation of gems using bundler or
+# waiting on a database connection. By defining them inside the commands section, they can be invoked as any standard
+# command on the system, but will already be preconfigured. This allows us to keep the jobs definition small and clean
+# ---------------------------------------------------------------------------------------------------------------------
+version: 2.1
+commands:
+  bundle_install:
+    description: "Performs the bundler installation, relying on the CircleCI cache for performance"
+    steps:
+      - restore_cache:
+          keys:
+            - bundler-cache-{{ checksum "is_it_up.gemspec" }}
+      - run:
+          name: "Bundle Install"
+          command: bundle install --path=.bundle
+      - save_cache:
+          key: bundler-cache-{{ checksum "is_it_up.gemspec" }}
+          paths:
+            - .bundle
+  minitest:
+    description: "Runs Minitest with the correct configuration so it runs in parallel and is configured for CircleCI"
+    steps:
+      - run:
+          name: "Minitest Test Suite"
+          command: bundle exec rake
+# ---------------------------------------------------------------------------------------------------------------------
+# CircleCI Job Configuration
+#
+# This section defines all the available jobs that can be executed inside a Workflow.
+# Think of a Job as a batch of tasks that need to be performed to setup the environment and perform a specific task
+# such as running RSpec, uploading the test results to CodeClimate etc.
+# ---------------------------------------------------------------------------------------------------------------------
+jobs:
+  tests:
+    working_directory: ~/is_it_up
+    docker:
+      - <<: *docker_image
+        environment:
+          RAILS_ENV: test
+    steps:
+      - checkout
+      - bundle_install
+      - minitest
+      - store_test_results:
+          path: test/reports
+      - store_artifacts:
+          path: coverage
+workflows:
+  version: 2.1
+  build-and-test:
+    jobs:
+      - tests:
+          context: customink

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ doc/
 lib/bundler/man
 pkg
 rdoc
-spec/reports
 test/tmp
 test/version_tmp
+test/reports
 tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# IsItUp Changelog
+
+## 0.0.3
+- Added `bin/console` for local testing
+- Added `bin/setup` for easier installation
+- Decoupled the gemspec from bundler and git
+- Applied Rubygem standards
+- Removed minitest deprecation warnings
+- Used `autoload` for configuring the gem

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in is_it_up.gemspec
 gemspec
+
+group :test do
+  gem 'minitest-ci', require: false
+  gem 'simplecov', require: false
+end

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'is_it_up'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require 'irb'
+::IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -e
+
+echo "== Running tests =="
+
+bundle exec rake test

--- a/is_it_up.gemspec
+++ b/is_it_up.gemspec
@@ -1,7 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'is_it_up/version'
+require_relative 'lib/is_it_up/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "is_it_up"
@@ -13,14 +10,17 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/customink/is_it_up"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = ::Dir.glob(::Pathname.new(__dir__).join("lib/**/**")).reject do |file|
+    file.match(%r{^(test|spec|features)/}) || ::File.directory?(file)
+  end
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rack"
+
   spec.add_development_dependency "rake"
   spec.add_development_dependency "json"
-  spec.add_development_dependency "bundler",  "~> 1.5"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/lib/is_it_up.rb
+++ b/lib/is_it_up.rb
@@ -1,7 +1,7 @@
 require "rack"
-require "is_it_up/version"
-require "is_it_up/middleware"
-require 'is_it_up/railtie' if defined?(Rails::Railtie)
 
 module IsItUp
+  autoload :VERSION, "is_it_up/version"
+  autoload :Middleware, "is_it_up/middleware"
+  autoload :railtie, "is_it_up/railtie" if defined?(Rails::Railtie)
 end

--- a/lib/is_it_up/version.rb
+++ b/lib/is_it_up/version.rb
@@ -1,3 +1,3 @@
 module IsItUp
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/test/cases/is_it_up_test.rb
+++ b/test/cases/is_it_up_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module IsItUp
   class IsItUpTest < TestCase
     it "must define the version" do
-      VERSION.wont_be_nil
+      refute_nil VERSION
     end
   end
 end

--- a/test/cases/middleware_test.rb
+++ b/test/cases/middleware_test.rb
@@ -23,13 +23,13 @@ module IsItUp
       end
 
       it "must respond with a JSON content type'" do
-        @response.content_type.must_equal "application/json"
+        assert_equal "application/json", @response.content_type
       end
 
       it "must render a JSON response indicating success'" do
         json = JSON.parse(@response.body)
-        json["status"].must_equal("ok")
-        json["code"].must_equal(200)
+        assert_equal "ok", json["status"]
+        assert_equal 200, json["code"]
       end
     end
 
@@ -39,11 +39,11 @@ module IsItUp
       end
 
       it "must not render the JSON content type" do
-        @response.content_type.must_equal "text/html"
+        assert_equal "text/html", @response.content_type
       end
 
       it "must not render the JSON response for /is_it_up" do
-        @response.body.must_equal "A normal response"
+        assert_equal "A normal response", @response.body
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,15 @@
-require "bundler" ; Bundler.require :development, :test
+if ENV['CI']
+  require 'simplecov'
+  SimpleCov.start
+end
+
+require "bundler"
+Bundler.require :development, :test
+
 require "is_it_up"
 require "minitest/autorun"
 require "minitest/pride"
+require "minitest/ci" if ENV["CI"]
 
 module IsItUp
   class TestCase < Minitest::Spec


### PR DESCRIPTION
### Description

This pull request cleans up the gems internals by applying a few standards to the code base.
This allows for better cross-platform development between macos and Linux, as well as preventing issues downstream.

### Changes

* Added a `bin/console` to start an IRB Console with IsItUp already loaded
* Added a `bin/setup` to install everything automatically
* Added a `rake` binstub to handle version conflicts
* Loosened the Bundler requirements
* Cleaned out some code to remove deprecation warnings
* Decoupled the Gemspec from bundler and git

