### PR TITLE
[Hotfix] Autloading Railtie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # IsItUp Changelog
 
+## 0.0.5
+- Fix the autoloading for `Railtie`
+
 ## 0.0.4
 - Added `.ruby-version` file with a recent version of Ruby
 - Added `Brewfile` with the GNU coreutils dependency

--- a/is_it_up.gemspec
+++ b/is_it_up.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "json"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rails"
 end

--- a/lib/is_it_up.rb
+++ b/lib/is_it_up.rb
@@ -3,5 +3,5 @@ require "rack"
 module IsItUp
   autoload :VERSION, "is_it_up/version"
   autoload :Middleware, "is_it_up/middleware"
-  autoload :railtie, "is_it_up/railtie" if defined?(Rails::Railtie)
+  autoload :Railtie, "is_it_up/railtie" if defined?(Rails::Railtie)
 end

--- a/lib/is_it_up/version.rb
+++ b/lib/is_it_up/version.rb
@@ -1,3 +1,3 @@
 module IsItUp
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/test/cases/is_it_up_test.rb
+++ b/test/cases/is_it_up_test.rb
@@ -5,5 +5,14 @@ module IsItUp
     it "must define the version" do
       refute_nil VERSION
     end
+
+    it 'properly loads Railtie constants' do
+      begin
+        require 'rails/railtie'
+        refute_nil VERSION
+      rescue NameError
+        fail('NameError was raised while loading Railtie')
+      end
+    end
   end
 end


### PR DESCRIPTION
### Description

This pull request fixes a typo in the gem to properly autoload Railtie.
Autoload requires constants with a capitalized name or throws errors.

### Changes

- Fixed the autoload directive

### Notes

Fixes `NameError: autoload must be constant name: railtie`