### PR TITLE
[DevOps] Hide AWS ECR URL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@
 # CircleCI configuration, reducing the complexity of the entire block.
 # ---------------------------------------------------------------------------------------------------------------------
 docker_image: &docker_image
-  image: 916869144969.dkr.ecr.us-east-1.amazonaws.com/customink/base-ruby:2.7-v4.0
+  image: ${CUSTOMINK_ECR_URL}/customink/base-ruby:2.7-v4.0
   aws_auth:
     aws_access_key_id: ${PRODUCTION_AWS_ACCESS_KEY_ID}
     aws_secret_access_key: ${PRODUCTION_AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
### Description

This pull request hides the ECR URL from the public configuration.
While not strictly a secret, this is not information to share with the public.
The URl is stored now in our CircleCI Context.

### Changes

- Hide the ECR URL